### PR TITLE
Fixes #2 adds entry point for sphinx versions prior to 1.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ from setuptools import setup
 import os.path
 import sys
 
+
 setup(
     name = 'sphinx_fossasia_theme',
     version = '0.0.1',
@@ -15,7 +16,10 @@ setup(
     entry_points = {
         'sphinx.html_themes': [
             'sphinx_fossasia_theme = sphinx_fossasia_theme'
-        ]
+        ],
+        'sphinx_themes': [
+            'path = sphinx_fossasia_theme:get_html_theme_path'
+        ],
     },
     install_requires = ['sphinx>=1.3'],
   	platforms = 'any',

--- a/sphinx_fossasia_theme/__init__.py
+++ b/sphinx_fossasia_theme/__init__.py
@@ -1,4 +1,9 @@
 from os import path
 
+
 def setup(app):
     app.add_html_theme('sphinx_fossasia_theme', path.abspath(path.dirname(__file__)))
+
+
+def get_html_theme_path():
+    return path.abspath(path.dirname(path.dirname(__file__)))


### PR DESCRIPTION
Instead of checking for sphinx versions and whatnot, I have simply added both entry points. setuptools seems to be handling this properly. Tested this locally with sphinx 1.6.3 and sphinx 1.5.5. This approach seems more cleaner as compared to checking sphinx version. More testing may be rquired before merge
