### PR TITLE
Fixes #12 Use img-responsive css for images

### DIFF
--- a/sphinx_fossasia_theme/static/fossasia.css_t
+++ b/sphinx_fossasia_theme/static/fossasia.css_t
@@ -118,3 +118,9 @@ a {
     background-color: #FFEB3B;
     border-radius: 10px;
 }
+
+img {
+    display: block;
+    max-width: 100%;
+    height: auto;
+}


### PR DESCRIPTION
### Related issue
Fixes #12 

### Description 
Bootstrap provides a basic class called `img-responsive` to make the images in a website responsive to changes in the dimensions of the screen. I added the contents of CSS involved in `img-responsive` to the `img` tag to make all the images in the documentation responsive


| Before        | After           | 
| ------------- |-------------|
| ![screenshot_20170712_182938](https://user-images.githubusercontent.com/8245662/28118933-b8158e96-6730-11e7-8d58-a301c1dfa1e3.png)      | ![screenshot_20170712_183008](https://user-images.githubusercontent.com/8245662/28118940-c1991244-6730-11e7-8813-cc5ac839ff89.png) |

